### PR TITLE
Small Update to Lesson Instructions README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@ We're going to build Airbnb. Really. We're going to take this in steps. First
 let's work on our model associations and write migrations. This will be
 challenging, but doable. Take it slow and work together. Follow the model specs.
 
-**_Before anything_**, note that when you generate models, controllers, etc,
-be sure to include this option, so that it skips tests (which we already have):
-`--no-test-framework`
-
 ## Where to Begin
 
-First think about the relations between all of the objects. Let's work through
+First, you will have to set up your migration files in order for the tests to run. Take a look at the spec files for an idea of how to build each table.
+Once you run your migrations, think about the relations between all of the objects. Let's work through
 Users and Listings, and from there you should know some cool ActiveRecord tricks
 to get started on the rest.
 


### PR DESCRIPTION
In the grand, ongoing saga of improving this curriculum one line at a time, I found myself reflecting on the timeless relationship between learners and the words that guide them. Documentation, as we all know, is both a lighthouse in the fog and a double-edged sword—capable of either illuminating the path forward or plunging the unwary into needless confusion. For students entering this lab, clarity is not simply a courtesy, it is the cornerstone upon which confidence and mastery are built.

Over the course of reviewing the material, I observed that the instructions, while fundamentally sound, had within them a subtle opportunity: a chance to smooth the learning journey, reduce the potential for head-scratching, and align the written guide more closely with the spirit of the lab itself. To be sure, these were not monumental flaws, nor the sort of changes that one might expect to inspire a standing ovation at a conference of pedagogues and technologists. But as anyone who has ever been led astray by a single unclear phrase will tell you, the smallest turn of phrase can become the largest stumbling block.

It is in that spirit—of incremental improvement, of patient attention to detail, of a belief that better words lead to better learning—that this PR arrives. While no sweeping architectural changes were made, and no core logic altered, what you will find herein is a quiet, careful adjustment: a refinement of the README instructions themselves

I updated the lesson instructions in the README so they are clearer and more helpful for students.
